### PR TITLE
t411.li

### DIFF
--- a/t411/__init__.py
+++ b/t411/__init__.py
@@ -14,7 +14,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 'T411',
-            'description': 'See <a href="https://t411.ch">T411</a>',
+            'description': 'See <a href="https://t411.li">T411</a>',
             'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAA3NCSVQICAjb4U/gAAACdklEQVQokW2RX0hTcRTHz+/+cbvz3m1srbv8M6Ws6SbK1hRTkUoKIui5jIJ8sz9vQQTRQxDRexCkIGgmSC+B1YNWNCIrRQ3Z2PyTf5pb2/S2ud2/2723hyIt/b4cDud7+H4OB2CXrpOW+wYLYPju0R66DTABEAWYB7i6lwHtbEYAKi5crPE36Wa6QGKQyYylk1cePPwX4FqPquSSiZVHAN+Gh/JihpezUpGXinmxkBN5Lvjm5U4/1hzwS5JsJIkzkWnmZDtSZF2WQZZ0SSoIgiSJXq+37VjLNhLL7h/ofUzg0Dceutl1ejHOoa0fScUQW1rouXQWw3ANULXbt8cNJ7pudPrcd/pmLp8PBNpa344HDYTqYc2Ls58G+59sI/0uTgBTKj78OQIdTb6W5gKg+PpKaPprUoLB/mBHY/v/CacARru7ucaG6NCrj5vp2rpDWvmBDa83PzDwdJVOl5Zo8S+JQhoD7E/CGMBEKLyYTNWjLKNl6KkP5OsXbE1leGqdNFoBd3K034jbcJzYfqfPTpUZjOHkmkmS+SpzinXYlxdGM+4I5ezkoyHSUcIjHXHY3wWPqM9SOg2ataFMlvQ6YWs5FIvaKxxgmzEfrWYOazanXuAxAGBwGALoNcWePxtx8cKR4wGuBFZo05TI2gXViE3SaiyVn3bQRgU0DABuVdHn7na6iuSMAOk2X6WnrqLcMVlqTVQ5lHw2VaQURtNN+7YoD7L4cQCQKGo9GJsUEGC6bNPfzc1xpZAjWuH7+3u+xHy+BuFLLkYsx7la0yrCAeqdZg0h1kDQFkpVlSyvrG1krM5mNbtK/9wM0wddjF6UNywElpWVX6HUDxDMdBkmAAAAAElFTkSuQmCC',
             'wizard': True,
             'options': [

--- a/t411/main.py
+++ b/t411/main.py
@@ -18,12 +18,12 @@ log = CPLog(__name__)
 class t411(TorrentProvider, MovieProvider):
 
     urls = {
-        'test' : 'https://t411.ch',
-        'login' : 'https://api.t411.ch/auth',
-        'login_check': 'https://api.t411.ch/torrents/top/100',
-        'detail' : 'https://www.t411.ch/torrents/?id=%s',
-        'search' : 'https://api.t411.ch/torrents/search/%s?limit=200&cid=631',
-        'download' : 'https://api.t411.ch/torrents/download/%s',
+        'test' : 'https://t411.li',
+        'login' : 'https://api.t411.li/auth',
+        'login_check': 'https://api.t411.li/torrents/top/100',
+        'detail' : 'https://www.t411.li/torrents/?id=%s',
+        'search' : 'https://api.t411.li/torrents/search/%s?limit=200&cid=631',
+        'download' : 'https://api.t411.li/torrents/download/%s',
     }
 
     cat_ids = [


### PR DESCRIPTION
Une mise a jour du domaine vers t411.li qui est fonctionnel depuis le 19/11/2016.